### PR TITLE
Generalise the fixing of feeding kernel for all filter feeders

### DIFF
--- a/fZooMSS_Setup.R
+++ b/fZooMSS_Setup.R
@@ -189,6 +189,7 @@ fZooMSS_Setup <- function(param){
         w0idx <- which(round(param$Groups$W0[i],2)==round(log10(param$w),2))
         sp_phyto_predkernel <- matrix(sp_phyto_predkernel[w0idx,], nrow = param$ngrid, ncol = param$ngridPP, byrow = TRUE)
         sp_dynam_predkernel <- matrix(sp_dynam_predkernel[w0idx,], nrow = param$ngrid, ncol = param$ngrid, byrow = TRUE)
+        rm(w0idx)
       }
 
     } else { # If group is fish


### PR DESCRIPTION
I've replaced the explicit reference to salps and larvaceans and fixed minimum weight bin with code that will apply to any filter feeder with any minimum size and any choice of weight grid.